### PR TITLE
Custom loading screen tips and misc changes

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -51,21 +51,22 @@ namespace SSSoftcoded
             StaticEntities.LoadingScreenTips = newTips.ToArray();
         }
     }
-}
 
-[HarmonyPatch(typeof(LoadingScreen), "SetupBackground")]
-class SetupBackgroundPatch
-{
-    static bool Prefix(LoadingScreen __instance)
+
+    [HarmonyPatch(typeof(LoadingScreen), "SetupBackground")]
+    class SetupBackgroundPatch
     {
-        GameObject gameObject = GameObject.Find("Wallpaper");
-        SSSLoadableResource[] wallpapers = SSSLoadingHelper.GetCustomWallPapers();
-        SSSLoadableResource chosenWallpaper = wallpapers[UnityEngine.Random.Range(0, wallpapers.Length - 1)];
-        Texture2D texture2D;
-        if (chosenWallpaper.GetExtension() != "")
+        static bool Prefix(LoadingScreen __instance)
         {
-            texture2D = SSSLoadingHelper.LoadWallpaperTexture(chosenWallpaper);
-        } else
+            GameObject gameObject = GameObject.Find("Wallpaper");
+            SSSLoadableResource[] wallpapers = SSSLoadingHelper.GetCustomWallPapers();
+            SSSLoadableResource chosenWallpaper = wallpapers[UnityEngine.Random.Range(0, wallpapers.Length - 1)];
+            Texture2D texture2D;
+            if (chosenWallpaper.GetExtension() != "")
+            {
+                texture2D = SSSLoadingHelper.LoadWallpaperTexture(chosenWallpaper);
+            }
+            else
             {
                 texture2D = UnityEngine.Resources.Load("UI/Loading/Backgrounds/" + chosenWallpaper.GetName()) as Texture2D;
             }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -19,10 +19,14 @@ namespace SSSoftcoded
         private void Awake()
         {
             Logger.LogInfo($"Loaded {PluginInfo.PLUGIN_GUID} {PluginInfo.PLUGIN_VERSION}!");
+            DoPatching();
+        }
+
+        private void Start()
+        {
             SSSLoadingHelper.Initialise();
             SSSLoadingHelper.DocumentAllCustomContent();
-
-            DoPatching();
+            CustomLoadingScreenTips();
         }
 
         private void DoPatching()
@@ -33,7 +37,6 @@ namespace SSSoftcoded
             Harmony.CreateAndPatchAll(typeof(StopAmbientFXPatch));
             Harmony.CreateAndPatchAll(typeof(PlayRegularSFXPatch));
             Harmony.CreateAndPatchAll(typeof(StopRegularSFXPatch));
-            CustomLoadingScreenTips();
         }
 
         private static void CustomLoadingScreenTips()

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -51,6 +51,12 @@ namespace SSSoftcoded
                 // Add old tips to the loading tips list
                 newTips.AddRange(oldTips);
             }
+            else if (customTips.Length == 0) // if the user ignores vanilla tips, but doesn't provide their own
+            {
+                // Add a fallback tip to prevent a crash, and to inform the user of the fact they've disabled vanilla tips without providing new ones
+                newTips.Add("Ignore Vanilla Loading Screen Tips is enabled, but no custom tips have been provided.");
+            }
+
             StaticEntities.LoadingScreenTips = newTips.ToArray();
         }
     }

--- a/SSSLoadingHelper.cs
+++ b/SSSLoadingHelper.cs
@@ -18,11 +18,14 @@ namespace SSSoftcoded
         private static string regularSFXFilePath = GameProvider.Instance.GetApplicationPath("audio/sfx/");
 
         private static bool ignoreVanillaWallpapers = false;
+        public static bool ignoreVanillaLoadingScreenTips = false;
 
         private static SSSLoadableResource[] customWallpapers;
         private static SSSLoadableResource[] customMusicTracks;
         private static SSSLoadableResource[] customAmbientSFX;
         private static SSSLoadableResource[] customRegularSFX;
+
+        private static string[] customLoadingScreenTips;
 
         private static List<AudioClip> loadedAmbientSFX = new List<AudioClip>();
         private static List<AudioClip> loadedRegularSFX = new List<AudioClip>();
@@ -36,18 +39,15 @@ namespace SSSoftcoded
 
                 foreach (var s in lines)
                 {
-                    s.Trim();
+                    string line = s.Trim();
 
-                    if (s.StartsWith("#") || s.StartsWith("["))
+                    if (line.Contains("="))
                     {
-                        continue;
-                    }
-                    else if (s.Contains("="))
-                    {
-                        string[] split = s.Split('=');
+                        string[] split = line.Split('=');
                         optionsDict.Add(split[0], split[1]);
                     }
                 }
+
 
                 if (optionsDict["customWallpapers"] != "")
                 {
@@ -68,6 +68,10 @@ namespace SSSoftcoded
                 if (optionsDict["ignoreVanillaWallpapers"] == "true")
                 {
                     ignoreVanillaWallpapers = true;
+                }
+                if (optionsDict["ignoreVanillaLoadingScreenTips"] == "true")
+                {
+                    ignoreVanillaLoadingScreenTips = true;
                 }
             } else
             {
@@ -251,6 +255,11 @@ namespace SSSoftcoded
         public static SSSLoadableResource[] GetCustomWallPapers()
         {
             return customWallpapers;
+        }
+
+        public static string[] GetCustomLoadingScreenTips()
+        {
+            return customLoadingScreenTips;
         }
 
         public static SSSLoadableResource[] GetCustomMusicTracks()

--- a/SSSLoadingHelper.cs
+++ b/SSSLoadingHelper.cs
@@ -48,7 +48,6 @@ namespace SSSoftcoded
                     }
                 }
 
-
                 if (optionsDict["customWallpapers"] != "")
                 {
                     wallpaperFilePath = CorrectFilePath(optionsDict["customWallpapers"]);

--- a/SSSLoadingHelper.cs
+++ b/SSSLoadingHelper.cs
@@ -39,7 +39,7 @@ namespace SSSoftcoded
 
                 foreach (var s in lines)
                 {
-                    string line = s.Trim();
+                    string line = s.Replace(" ", "");
 
                     if (line.Contains("="))
                     {

--- a/SSSoftcoded.csproj
+++ b/SSSoftcoded.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>SSSoftcoded</AssemblyName>
-    <Description>My first plugin</Description>
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Adds the ability to load new loading screen tips. **Note:** I haven’t implemented the actual loading process for the tips themselves, only the application of them within the game. This is so you can retain complete control over how and from where the tips are loaded.

I've also made some minor fixes and quality-of-life adjustments, such as changing:
```cs
[BepInPlugin("mod.clevercrumbish.SSSoftcoded", "Sunless Sea Softcoded", "1.0.0")]
```
to
```cs
[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
```

And some minor simplifications and improvements of if statements and loops.

### Important

While I’ve tested these changes using DNSpy and in SDLS (by adding it to the mod as a test), I haven't been able to fully compile this mod due to unrelated issues on my end. Some examples include errors like `'GameProvider' does not contain a definition for 'GetApplicationPath'`.

If possible, please test the mod yourself, or let me know if you'd like me to address these errors. (It appears `GetApplicationPath` is internal, I'm curious how you're accessing it?)